### PR TITLE
Update main.swift

### DIFF
--- a/Sources/SwiftBelt/main.swift
+++ b/Sources/SwiftBelt/main.swift
@@ -73,7 +73,7 @@ func SecCheck(){
             print("\(green)[+] FireEye HX agent installed\(colorend)")
             b = 1
         }
-        if processes2.contains("falconctl") || fileMan.fileExists(atPath: "/Library/CS/falcond") || fileMan.fileExists(atPath: "/Applications/Falcon.app/Contents/Resources") {
+        if processes2.contains("falcond") || fileMan.fileExists(atPath: "/Library/CS/falcond") || fileMan.fileExists(atPath: "/Applications/Falcon.app/Contents/Resources",isDirectory: &isDir) {
             print("\(green)[+] Crowdstrike Falcon agent found\(colorend)")
             b = 1
         }


### PR DESCRIPTION
Minor tweak to change falconctl to falcond for the Crowdstrike check. The falcond is the the running daemon on the system, whereas falconctl is more of a utility binary used when configuring new agents or retrieving stats. I also tweaked the last check for falcon to include the isDirectory instance method.